### PR TITLE
Stops empty block production amd sets min period to zero

### DIFF
--- a/geth-poa/genesis.json
+++ b/geth-poa/genesis.json
@@ -15,7 +15,7 @@
       "arrowGlacierBlock": 0,
       "grayGlacierBlock": 0,
       "clique": {
-        "period": 200,
+        "period": 0,
         "epoch": 30000
       }
     },


### PR DESCRIPTION
The reason for this change is because the block sealing process was setting the header.Time timestamp into the future, delaying consensus approximately ~200ms beyond when the transactions were applied to the EVM. This could result in situations where transactions are applied correctly during simulation, but fail once consensus check is complete, because the final header.Time is 200ms into the future of the initial simulation.  
```
	header.Time = parent.Time + c.config.PeriodMs
	if header.Time < uint64(time.Now().UnixMilli()) {
		header.Time = uint64(time.Now().UnixMilli())
	}
```


* We reduce the minimum block period to zero, this allows for blocks to be produced at any time.
* The only restriction that will be left, is that timestamp progresses forward in time, however, this is of little relevance as there will be only one clock (in the single signer node), so this restriction would be satisfied irrespectively.
* Another aspect is that blocks will now only be produced when transactions are included in the block (e.g no empty blocks)
```go
	// For 0-period chains, refuse to seal empty blocks (no reward but would spin sealing)
	if c.config.PeriodMs == 0 && len(block.Transactions()) == 0 {
		return errors.New("sealing paused while waiting for transactions")
	}
```
* This change has been tested on a latitude server and produces significant latency improvements and will likely also improve disk utilization 