### PR TITLE
feat: introduces BLS signature verification precompile

### DIFF
--- a/geth-poa/genesis.json
+++ b/geth-poa/genesis.json
@@ -12,6 +12,7 @@
       "muirGlacierBlock": 0,
       "berlinBlock": 0,
       "londonBlock": 0,
+      "cancunTime": 0,
       "arrowGlacierBlock": 0,
       "grayGlacierBlock": 0,
       "clique": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ethereum/go-ethereum
 
-go 1.20
+go 1.22.0
+
+toolchain go1.23.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
@@ -91,6 +93,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect
 	github.com/cockroachdb/redact v1.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86c
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.5.0 h1:hxIWksrX6XN5a1L2TI/h53AGPhNHoUBo+TD1ms9+pys=
+github.com/cloudflare/circl v1.5.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cloudflare/cloudflare-go v0.79.0 h1:ErwCYDjFCYppDJlDJ/5WhsSmzegAUe2+K9qgFyQDg3M=
 github.com/cloudflare/cloudflare-go v0.79.0/go.mod h1:gkHQf9xEubaQPEuerBuoinR9P8bf8a05Lq0X6WKy1Oc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -159,6 +159,8 @@ const (
 	Bls12381MapG1Gas          uint64 = 5500   // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 110000 // Gas price for BLS12-381 mapping field element to G2 operation
 
+	BlsSignVerifyGas uint64 = 150000 // Gas price for BLS12-381 signature verification
+
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2


### PR DESCRIPTION
# Introduction of BLS Signature Verification Precompile

This PR introduces a new precompiled contract for **BLS signature verification** using the **BLS12-381 curve**. The `bls12381SignatureVerification` struct enables Ethereum smart contracts to efficiently verify BLS signatures (e.g validate a message was signed by a target public key). This will be useful in the context of ensuring that builders who register have access to the BLS key they sign up with.


### Details for usage 
- **Gas Cost**: Is currently set to **150000 wei.**
- **Input Format**:  The input is a concatenation of three components:

```plaintext
+---------------------+---------------------+-----------------------+
|     Public Key      |       Message       |       Signature       |
|     (48 bytes)      |      (32 bytes)     |       (96 bytes)      |
|      G1 Point       | Hash of the Message |       G2 Point        |
+---------------------+---------------------+-----------------------+
```
Note: We assume the public key is a point on the G1 curve. 

## Example Usage: Solidity Contract

The following example demonstrates how to interact with the BLS signature verification precompile via a smartcontract:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

contract BLSVerifier {
    // Precompile address
    address constant BLS_VERIFY = address(0xf0);

    /**
     * @dev Verifies a BLS signature using the precompile
     * @param pubKey The public key (48 bytes G1 point)
     * @param message The message hash (32 bytes)
     * @param signature The signature (96 bytes G2 point)
     * @return success True if verification succeeded
     */
    function verifySignature(
        bytes calldata pubKey,
        bytes32 message,
        bytes calldata signature
    ) public view returns (bool) {
        // Input validation
        require(pubKey.length == 48, "Public key must be 48 bytes");
        require(signature.length == 96, "Signature must be 96 bytes");

        // Concatenate inputs in required format:
        // [pubkey (48 bytes) | message (32 bytes) | signature (96 bytes)]
        bytes memory input = bytes.concat(
            pubKey,
            message,
            signature
        );

        // Call precompile
        (bool success, bytes memory result) = BLS_VERIFY.staticcall(input);
        
        // Check if call was successful
        if (!success) {
            return false;
        }

        // If we got a result back and it's not empty, verification succeeded
        return result.length > 0;
    }
}
```

The video demo can be seen [here](https://www.loom.com/share/d3f957f6bd8c48139d5263fe97aef252?sid=98fef86b-1a49-4d84-a9b3-6f64e19c6cd1) 
