### PR TITLE
feat: Add Support for Zero Fee Addresses

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -464,7 +464,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		// Send both base and prio fee to preconf.eth address
 		treasuryAccount := common.HexToAddress("0xfA0B0f5d298d28EFE4d35641724141ef19C05684")
 		bothFees := baseFee.Add(baseFee, priorityFee)
-		st.state.AddBalance(treasuryAccount, bothFees)
+
+		// @shaspitz do we note want to also remove the fee from the sender account, even when we increment the treasury account?
+		if st.evm.ChainConfig().IsZeroFee(sender.Address()) {
+			st.state.AddBalance(sender.Address(), bothFees)
+		} else {
+			st.state.AddBalance(treasuryAccount, bothFees)
+		}
 	}
 
 	return &ExecutionResult{

--- a/geth-poa/genesis.json
+++ b/geth-poa/genesis.json
@@ -17,7 +17,10 @@
       "clique": {
         "period": 200,
         "epoch": 30000
-      }
+      },
+      "zeroFeeAddresses": [
+        "0xfA0B0f5d298d28EFE4d35641724141ef19C05684"
+      ]
     },
     "nonce": "0x0",
     "timestamp": "0x18E0A4E0D22",

--- a/params/config.go
+++ b/params/config.go
@@ -19,6 +19,7 @@ package params
 import (
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params/forks"
@@ -364,6 +365,8 @@ type ChainConfig struct {
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
 	Clique *CliqueConfig `json:"clique,omitempty"`
+
+	ZeroFeeAddresses []common.Address `json:"zeroFeeAddresses,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -575,6 +578,10 @@ func (c *ChainConfig) IsPrague(num *big.Int, time uint64) bool {
 // IsVerkle returns whether num is either equal to the Verkle fork time or greater.
 func (c *ChainConfig) IsVerkle(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.VerkleTime, time)
+}
+
+func (c *ChainConfig) IsZeroFee(address common.Address) bool {
+	return slices.Contains(c.ZeroFeeAddresses, address)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported


### PR DESCRIPTION
This PR introduces support for zero fee addresses in the Ethereum state transition logic and configuration. This will ensure accounts like the Oracle and Relayer for the bridge never run out of funds.

Note: to set the whitelisted accounts, you must configure them in the genesis file.