### PR TITLE
feat: moves the BLS precompile to berlin

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -91,6 +91,9 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{7}): &bn256ScalarMulIstanbul{},
 	common.BytesToAddress([]byte{8}): &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{9}): &blake2F{},
+
+	// primev pre-compiles start at 0xf addresses
+	common.BytesToAddress([]byte{0xf0}): &bls12381SignatureVerification{},
 }
 
 // PrecompiledContractsCancun contains the default set of pre-compiled Ethereum
@@ -106,9 +109,6 @@ var PrecompiledContractsCancun = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}):    &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{9}):    &blake2F{},
 	common.BytesToAddress([]byte{0x0a}): &kzgPointEvaluation{},
-
-	// primev pre-compiles start at 0xf addresses
-	common.BytesToAddress([]byte{0xf0}): &bls12381SignatureVerification{},
 }
 
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum


### PR DESCRIPTION
* Since cancun upgrade wasn't correctly activating, moving the precompile to berlin upgrade